### PR TITLE
People with first name shorter then 4 characters will be excluded.

### DIFF
--- a/Employee.Test.Git.Merge/Employee.Test.Git.Merge/Services/TestService.cs
+++ b/Employee.Test.Git.Merge/Employee.Test.Git.Merge/Services/TestService.cs
@@ -17,7 +17,11 @@ namespace Employee.Test.Git.Merge.Services
 
         public List<string> PeopleNames()
         {
-            return _testRepository.GetPeopleNames();
+            var peopleNames = _testRepository.GetPeopleNames();
+
+            List<string> noShortFirstNames = peopleNames.Where(name => name.Split(' ')[0].Length > 3).ToList();
+
+            return noShortFirstNames;
         }
     }
 }


### PR DESCRIPTION
Merging allCapsedNames with excludeShortFirstNames